### PR TITLE
Hotfix regarding lookup of migration types

### DIFF
--- a/HiP-EventStoreLib/HiP-EventStoreLib.csproj
+++ b/HiP-EventStoreLib/HiP-EventStoreLib.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>PaderbornUniversity.SILab.Hip.EventSourcing</RootNamespace>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <Version>0.12.0</Version>
+    <Version>0.13.0</Version>
     <Authors>HiP Devs</Authors>
     <Description>Provides core functionality for implementing the event sourcing and CQRS patterns.</Description>
     <Copyright></Copyright>

--- a/HiP-EventStoreLib/HiP-EventStoreLib.csproj
+++ b/HiP-EventStoreLib/HiP-EventStoreLib.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>PaderbornUniversity.SILab.Hip.EventSourcing</RootNamespace>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
     <Authors>HiP Devs</Authors>
     <Description>Provides core functionality for implementing the event sourcing and CQRS patterns.</Description>
     <Copyright></Copyright>

--- a/HiP-EventStoreLib/HiP-EventStoreLib.csproj
+++ b/HiP-EventStoreLib/HiP-EventStoreLib.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>PaderbornUniversity.SILab.Hip.EventSourcing</RootNamespace>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <Version>0.11.0</Version>
+    <Version>0.12.0</Version>
     <Authors>HiP Devs</Authors>
     <Description>Provides core functionality for implementing the event sourcing and CQRS patterns.</Description>
     <Copyright></Copyright>


### PR DESCRIPTION
Before this PR, migration types could not be located because only the EventStoreLib-assembly was searched, not the assembly of the calling service (e.g. DataStore).

Just approve, it's already used in production anyway...