### PR TITLE
Refactored NuGet packaging

### DIFF
--- a/HiP-EventStoreLib/HiP-EventStoreLib.csproj
+++ b/HiP-EventStoreLib/HiP-EventStoreLib.csproj
@@ -7,6 +7,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Version>0.15.0</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
+	<GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>HiP Devs</Authors>
     <Description>Provides core functionality for implementing the event sourcing and CQRS patterns.</Description>
     <Copyright></Copyright>

--- a/NuGetPack.ps1
+++ b/NuGetPack.ps1
@@ -6,4 +6,4 @@ Switch ("$env:Build_SourceBranchName")
 }
 
 $nupkg = (ls HiP-EventStoreLib\*.nupkg).FullName
-dotnet nuget push "$nupkg" -k "$env:MyGetKey" -s "$env:MyGetFeed"
+dotnet nuget push "$nupkg" -k "$env:MyGetKey" -s "$env:NuGetFeed"


### PR DESCRIPTION
According to the guidelines on Confluence, the packaging script should use the "NuGetFeed"-variable instead of "MyGetFeed".