### PR TITLE
Default value for EventStoreConfig.Host

### DIFF
--- a/HiP-EventStoreLib/EventStoreLlp/EventStoreConfig.cs
+++ b/HiP-EventStoreLib/EventStoreLlp/EventStoreConfig.cs
@@ -7,6 +7,7 @@
     {
         /// <summary>
         /// Endpoint of the Event Store.
+        /// Default value: "tcp://localhost:1113"
         /// 
         /// Examples:
         /// "tcp://localhost:1113",
@@ -15,12 +16,12 @@
         /// 
         /// See also: http://docs.geteventstore.com/dotnet-api/4.0.0/connecting-to-a-server/
         /// </summary>
-        public string Host { get; set; }
+        public virtual string Host { get; set; } = "tcp://localhost:1113";
 
         /// <summary>
         /// Name of the event stream to read from and write to.
         /// For example, you can use different streams for develop and production environments.
         /// </summary>
-        public string Stream { get; set; }
+        public virtual string Stream { get; set; }
     }
 }

--- a/HiP-EventStoreLib/EventStoreLlp/EventStoreConfig.cs
+++ b/HiP-EventStoreLib/EventStoreLlp/EventStoreConfig.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Specifies the configuration fields that are required for <see cref="EventStoreService"/> to work.
     /// </summary>
-    public class EventStoreConfig
+    public sealed class EventStoreConfig
     {
         /// <summary>
         /// Endpoint of the Event Store.
@@ -16,12 +16,12 @@
         /// 
         /// See also: http://docs.geteventstore.com/dotnet-api/4.0.0/connecting-to-a-server/
         /// </summary>
-        public virtual string Host { get; set; } = "tcp://localhost:1113";
+        public string Host { get; set; } = "tcp://localhost:1113";
 
         /// <summary>
         /// Name of the event stream to read from and write to.
         /// For example, you can use different streams for develop and production environments.
         /// </summary>
-        public virtual string Stream { get; set; }
+        public string Stream { get; set; }
     }
 }

--- a/HiP-EventStoreLib/HiP-EventStoreLib.csproj
+++ b/HiP-EventStoreLib/HiP-EventStoreLib.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>PaderbornUniversity.SILab.Hip.EventSourcing</RootNamespace>
     <NoWarn>1701;1702;1705;1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.1.1</Version>
+    <Version>1.1.2</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
     <Description>Provides core functionality for implementing the event sourcing and CQRS patterns.</Description>
     <PackageLicenseUrl>https://github.com/HiP-App/HiP-EventStoreLib/blob/master/LICENSE</PackageLicenseUrl>

--- a/HiP-EventStoreLib/HiP-EventStoreLib.csproj
+++ b/HiP-EventStoreLib/HiP-EventStoreLib.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>PaderbornUniversity.SILab.Hip.EventSourcing</RootNamespace>
     <NoWarn>1701;1702;1705;1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
     <Description>Provides core functionality for implementing the event sourcing and CQRS patterns.</Description>
     <PackageLicenseUrl>https://github.com/HiP-App/HiP-EventStoreLib/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
EventStoreConfig properties are now virtual so that default values can be overridden. Together with the changes in HiP-WebserviceLib, this allows us to reduce the configuration effort down to a minimum which (a) makes it easier to configure services in Docker cloud, (b) makes it easier for new PG members to set up and run services on their dev machine.