### PR TITLE
FakeEventStore & FakeMonoDbContext are no longer singletons

### DIFF
--- a/HiP-EventStoreLib/FakeStore/FakeEventStore.cs
+++ b/HiP-EventStoreLib/FakeStore/FakeEventStore.cs
@@ -8,13 +8,24 @@ namespace PaderbornUniversity.SILab.Hip.EventSourcing.FakeStore
     /// </summary>
     public class FakeEventStore : IEventStore
     {
-        public static readonly FakeEventStore Instance = new FakeEventStore();
+        /// <summary>
+        /// Gets the latest instance of <see cref="FakeEventStore"/>.
+        /// </summary>
+        public static FakeEventStore Current { get; private set; }
 
         public FakeEventStreamCollection Streams { get; }
 
         IEventStreamCollection IEventStore.Streams => Streams;
 
-        public FakeEventStore() => Streams = new FakeEventStreamCollection(this);
+        /// <summary>
+        /// Initializes a new <see cref="FakeEventStore"/> and sets it as the
+        /// current instance (see <see cref="Current"/>).
+        /// </summary>
+        public FakeEventStore()
+        {
+            Current = this;
+            Streams = new FakeEventStreamCollection(this);
+        }
     }
 
     public class FakeEventStreamCollection : IEventStreamCollection

--- a/HiP-EventStoreLib/HiP-EventStoreLib.csproj
+++ b/HiP-EventStoreLib/HiP-EventStoreLib.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>PaderbornUniversity.SILab.Hip.EventSourcing</RootNamespace>
     <NoWarn>1701;1702;1705;1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>2.0.1</Version>
+    <Version>3.0.0</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
     <Description>Provides core functionality for implementing the event sourcing and CQRS patterns.</Description>
     <PackageLicenseUrl>https://github.com/HiP-App/HiP-EventStoreLib/blob/master/LICENSE</PackageLicenseUrl>

--- a/HiP-EventStoreLib/Mongo/Test/FakeMongoDbContext.cs
+++ b/HiP-EventStoreLib/Mongo/Test/FakeMongoDbContext.cs
@@ -14,11 +14,23 @@ namespace PaderbornUniversity.SILab.Hip.EventSourcing.Mongo.Test
     /// </remarks>
     public class FakeMongoDbContext : IMongoDbContext
     {
-        public static readonly FakeMongoDbContext Instance = new FakeMongoDbContext();
+        /// <summary>
+        /// Gets the latest instance of <see cref="FakeMongoDbContext"/>.
+        /// </summary>
+        public static FakeMongoDbContext Current { get; private set; }
 
         private readonly Dictionary<EntityId, IEntity<int>> _entities = new Dictionary<EntityId, IEntity<int>>();
         private readonly Dictionary<EntityId, HashSet<EntityId>> _incomingRefs = new Dictionary<EntityId, HashSet<EntityId>>();
         private readonly Dictionary<EntityId, HashSet<EntityId>> _outgoingRefs = new Dictionary<EntityId, HashSet<EntityId>>();
+
+        /// <summary>
+        /// Initializes a new <see cref="FakeMongoDbContext"/> and sets it as the
+        /// current instance (see <see cref="Current"/>).
+        /// </summary>
+        public FakeMongoDbContext()
+        {
+            Current = this;
+        }
 
         private HashSet<EntityId> IncomingRefs(EntityId id) =>
             _incomingRefs.TryGetValue(id, out var list)


### PR DESCRIPTION
This change has to do with testing.

Individual tests should be as isolated as possible, that's why it wasn't a good idea to make `FakeEventStore` & `FakeMongoDbContext` singletons. `TestStartup`-classes should now register new instances of these classes every time instead of using a single shared instance. Otherwise, data from one test might be visible in another test, causing it to fail.

There's still a static property to obtain the "current" instance of each type, i.e. the one registered for that test.