### PR TITLE
More testing-related changes

### DIFF
--- a/HiP-EventStoreLib/FakeStore/FakeEventStore.cs
+++ b/HiP-EventStoreLib/FakeStore/FakeEventStore.cs
@@ -8,24 +8,11 @@ namespace PaderbornUniversity.SILab.Hip.EventSourcing.FakeStore
     /// </summary>
     public class FakeEventStore : IEventStore
     {
-        /// <summary>
-        /// Gets the latest instance of <see cref="FakeEventStore"/>.
-        /// </summary>
-        public static FakeEventStore Current { get; private set; }
-
         public FakeEventStreamCollection Streams { get; }
 
         IEventStreamCollection IEventStore.Streams => Streams;
 
-        /// <summary>
-        /// Initializes a new <see cref="FakeEventStore"/> and sets it as the
-        /// current instance (see <see cref="Current"/>).
-        /// </summary>
-        public FakeEventStore()
-        {
-            Current = this;
-            Streams = new FakeEventStreamCollection(this);
-        }
+        public FakeEventStore() => Streams = new FakeEventStreamCollection(this);
     }
 
     public class FakeEventStreamCollection : IEventStreamCollection

--- a/HiP-EventStoreLib/HiP-EventStoreLib.csproj
+++ b/HiP-EventStoreLib/HiP-EventStoreLib.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>PaderbornUniversity.SILab.Hip.EventSourcing</RootNamespace>
     <NoWarn>1701;1702;1705;1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.0.0</Version>
+    <Version>4.0.0</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
     <Description>Provides core functionality for implementing the event sourcing and CQRS patterns.</Description>
     <PackageLicenseUrl>https://github.com/HiP-App/HiP-EventStoreLib/blob/master/LICENSE</PackageLicenseUrl>

--- a/HiP-EventStoreLib/Mongo/Test/FakeMongoDbContext.cs
+++ b/HiP-EventStoreLib/Mongo/Test/FakeMongoDbContext.cs
@@ -14,23 +14,9 @@ namespace PaderbornUniversity.SILab.Hip.EventSourcing.Mongo.Test
     /// </remarks>
     public class FakeMongoDbContext : IMongoDbContext
     {
-        /// <summary>
-        /// Gets the latest instance of <see cref="FakeMongoDbContext"/>.
-        /// </summary>
-        public static FakeMongoDbContext Current { get; private set; }
-
         private readonly Dictionary<EntityId, IEntity<int>> _entities = new Dictionary<EntityId, IEntity<int>>();
         private readonly Dictionary<EntityId, HashSet<EntityId>> _incomingRefs = new Dictionary<EntityId, HashSet<EntityId>>();
         private readonly Dictionary<EntityId, HashSet<EntityId>> _outgoingRefs = new Dictionary<EntityId, HashSet<EntityId>>();
-
-        /// <summary>
-        /// Initializes a new <see cref="FakeMongoDbContext"/> and sets it as the
-        /// current instance (see <see cref="Current"/>).
-        /// </summary>
-        public FakeMongoDbContext()
-        {
-            Current = this;
-        }
 
         private HashSet<EntityId> IncomingRefs(EntityId id) =>
             _incomingRefs.TryGetValue(id, out var list)

--- a/HiP-EventStoreLib/ResourceType.cs
+++ b/HiP-EventStoreLib/ResourceType.cs
@@ -1,7 +1,7 @@
 ﻿using MongoDB.Bson.Serialization.Attributes;
 using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 
 namespace PaderbornUniversity.SILab.Hip.EventSourcing
 {
@@ -18,7 +18,8 @@ namespace PaderbornUniversity.SILab.Hip.EventSourcing
     /// </remarks>
     public class ResourceType : IEquatable<ResourceType>
     {
-        private static readonly Dictionary<string, ResourceType> Dictionary = new Dictionary<string, ResourceType>();
+        private static readonly ConcurrentDictionary<string, ResourceType> Dictionary = 
+            new ConcurrentDictionary<string, ResourceType>();
 
         /// <summary>
         /// This name is used in two ways:


### PR DESCRIPTION
* Removed static `Current`-properties from FakeEventStore & FakeMongoDbContext because they are of no use when tests are executed in parallel
* ResourceType now uses a ConcurrentDictionary to fix parallel test execution

New library version: v4.0.0