### PR TITLE
Fix for value type issue

### DIFF
--- a/HiP-EventStoreLib.Tests/EntityManagerTest.cs
+++ b/HiP-EventStoreLib.Tests/EntityManagerTest.cs
@@ -27,8 +27,8 @@ namespace PaderbornUniversity.SILab.Hip.EventSourcing.Tests
         public async void Test()
         {
             var resourceType = ResourceType.Register("TestObject", typeof(TestObject));
-            var testObject1 = new TestObject { Name = "Test1", Foo = new Foo { Id = 5, Parent = 3, Name = "Foo1", Bars = new List<int> { 1, 2, 3, 4 } } };
-            var testObject2 = new TestObject { Object = testObject1, Name = "Test2", Foo = new Foo { Id = 6, Parent = 7, Name = "Foo2", Bars = new List<int> { 1, 5, 3, 4 } } };
+            var testObject1 = new TestObject { Name = "Test1", Foo = new Foo { Id = 0, Parent = 3, Name = "Foo1", Bars = new List<int> { 1, 2, 3, 4 } } };
+            var testObject2 = new TestObject { Object = testObject1, Name = "Test2", Foo = new Foo { Id = 6, Parent = 7, Name = "Foo2", EnumValue = TestEnum.Enum2, Bars = new List<int> { 1, 5, 3, 4 } } };
             int id = 1;
             string userId = "";
 

--- a/HiP-EventStoreLib.Tests/Foo.cs
+++ b/HiP-EventStoreLib.Tests/Foo.cs
@@ -11,6 +11,7 @@ namespace PaderbornUniversity.SILab.Hip.EventSourcing.Tests
         public int Parent { get; set; }
 
         public List<int> Bars { get; set; }
+        public TestEnum EnumValue { get; set; }
 
         public override bool Equals(object obj)
         {
@@ -31,5 +32,10 @@ namespace PaderbornUniversity.SILab.Hip.EventSourcing.Tests
             hashCode = hashCode * -1521134295 + EqualityComparer<List<int>>.Default.GetHashCode(Bars);
             return hashCode;
         }
+    }
+
+    public enum TestEnum
+    {
+        Enum1, Enum2
     }
 }

--- a/HiP-EventStoreLib/EntityManager.cs
+++ b/HiP-EventStoreLib/EntityManager.cs
@@ -132,7 +132,7 @@ namespace PaderbornUniversity.SILab.Hip.EventSourcing
                             oldValue = Activator.CreateInstance(type, true);
                         }
 
-                        var methodInfo = typeof(EntityManager).GetMethod(nameof(CompareEntitiesInternal));
+                        var methodInfo = typeof(EntityManager).GetMethod(nameof(CompareEntitiesInternal), System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
                         var genericMethod = methodInfo.MakeGenericMethod(oldValue.GetType());
                         var events = (IEnumerable<PropertyChangedEvent>)genericMethod.Invoke(null, new[] { oldValue, newValue, resourceType, id, userId, BuildPath(propertyPath, prop.Name), ++recursionDepth, entityCreated });
 

--- a/HiP-EventStoreLib/EntityManager.cs
+++ b/HiP-EventStoreLib/EntityManager.cs
@@ -85,7 +85,7 @@ namespace PaderbornUniversity.SILab.Hip.EventSourcing
             return CompareEntitiesInternal(oldObject, newObject, resourceType, id, userId, "", 1);
         }
 
-        public static IEnumerable<PropertyChangedEvent> CompareEntitiesInternal<T>(T oldObject, T newObject, ResourceType resourceType, int id, string userId, string propertyPath, int recursionDepth, bool entityCreated = false)
+        private static IEnumerable<PropertyChangedEvent> CompareEntitiesInternal<T>(T oldObject, T newObject, ResourceType resourceType, int id, string userId, string propertyPath, int recursionDepth, bool entityCreated = false)
         {
             if (oldObject == null || newObject == null)
                 throw new ArgumentNullException("None of the objects to compare can be null");

--- a/HiP-EventStoreLib/EntityManager.cs
+++ b/HiP-EventStoreLib/EntityManager.cs
@@ -32,7 +32,8 @@ namespace PaderbornUniversity.SILab.Hip.EventSourcing
             var emptyObject = Activator.CreateInstance<T>();
             var createdEvent = new CreatedEvent(resourceType.Name, id, userId);
             await service.AppendEventAsync(createdEvent);
-            await UpdateEntityAsync(service, emptyObject, obj, resourceType, id, userId);
+            var events = CompareEntitiesInternal(emptyObject, obj, resourceType, id, userId, "", 1, true);
+            await service.AppendEventsAsync(events);
         }
 
         /// <summary>
@@ -50,7 +51,7 @@ namespace PaderbornUniversity.SILab.Hip.EventSourcing
 
         /// <summary>
         /// Updates an entity by appending <see cref="PropertyChangedEvent"/>s to the event stream.
-        /// Uses <see cref="CompareEntities{T}(T, T, ResourceType, int, string,string, int)"/> to compare the entities.
+        /// Uses <see cref="CompareEntities{T}(T, T, ResourceType, int, string)"/> to compare the entities.
         /// </summary>
         /// <typeparam name="T">Type of the entitiy</typeparam>
         /// <param name="service">EventStoreService</param>
@@ -76,11 +77,15 @@ namespace PaderbornUniversity.SILab.Hip.EventSourcing
         /// <param name="newObject">New entity</param>
         /// <param name="resourceType">Resource type</param>
         /// <param name="id">Id of the entity</param>
-        /// <param name="userId">Id of the user</param>
-        /// <param name="path">Property path</param>
-        /// <param name="recursionDepth">Depth of the recursion</param>
+        /// <param name="userId">Id of the user</param>        
         /// <returns>Enumerable of <see cref="PropertyChangedEvent"/>s</returns>
-        public static IEnumerable<PropertyChangedEvent> CompareEntities<T>(T oldObject, T newObject, ResourceType resourceType, int id, string userId, string path = "", int recursionDepth = 1)
+
+        public static IEnumerable<PropertyChangedEvent> CompareEntities<T>(T oldObject, T newObject, ResourceType resourceType, int id, string userId)
+        {
+            return CompareEntitiesInternal(oldObject, newObject, resourceType, id, userId, "", 1);
+        }
+
+        public static IEnumerable<PropertyChangedEvent> CompareEntitiesInternal<T>(T oldObject, T newObject, ResourceType resourceType, int id, string userId, string propertyPath, int recursionDepth, bool entityCreated = false)
         {
             if (oldObject == null || newObject == null)
                 throw new ArgumentNullException("None of the objects to compare can be null");
@@ -107,7 +112,7 @@ namespace PaderbornUniversity.SILab.Hip.EventSourcing
 
                     if (oldList == null || newList == null || !oldList.SequenceEqual(newList))
                     {
-                        yield return new PropertyChangedEvent(BuildPath(path, prop.Name), resourceType.Name, id, userId, newValue);
+                        yield return new PropertyChangedEvent(BuildPath(propertyPath, prop.Name), resourceType.Name, id, userId, newValue);
                     }
                 }
                 else if (prop.CustomAttributes.Any(d => d.AttributeType.Equals(typeof(NestedObjectAttribute))))
@@ -117,7 +122,7 @@ namespace PaderbornUniversity.SILab.Hip.EventSourcing
                     if (newValue == null)
                     {
                         //the nested object has been set to null
-                        yield return new PropertyChangedEvent(BuildPath(path, prop.Name), resourceType.Name, id, userId, newValue);
+                        yield return new PropertyChangedEvent(BuildPath(propertyPath, prop.Name), resourceType.Name, id, userId, newValue);
                     }
                     else
                     {
@@ -127,9 +132,9 @@ namespace PaderbornUniversity.SILab.Hip.EventSourcing
                             oldValue = Activator.CreateInstance(type, true);
                         }
 
-                        var methodInfo = typeof(EntityManager).GetMethod(nameof(CompareEntities));
+                        var methodInfo = typeof(EntityManager).GetMethod(nameof(CompareEntitiesInternal));
                         var genericMethod = methodInfo.MakeGenericMethod(oldValue.GetType());
-                        var events = (IEnumerable<PropertyChangedEvent>)genericMethod.Invoke(null, new[] { oldValue, newValue, resourceType, id, userId, BuildPath(path, prop.Name), ++recursionDepth });
+                        var events = (IEnumerable<PropertyChangedEvent>)genericMethod.Invoke(null, new[] { oldValue, newValue, resourceType, id, userId, BuildPath(propertyPath, prop.Name), ++recursionDepth, entityCreated });
 
                         foreach (var e in events)
                         {
@@ -137,9 +142,13 @@ namespace PaderbornUniversity.SILab.Hip.EventSourcing
                         }
                     }
                 }
+                else if (entityCreated && type.IsValueType)
+                {
+                    yield return new PropertyChangedEvent(BuildPath(propertyPath, prop.Name), resourceType.Name, id, userId, newValue);
+                }
                 else if (!Equals(oldValue, newValue))
                 {
-                    yield return new PropertyChangedEvent(BuildPath(path, prop.Name), resourceType.Name, id, userId, newValue);
+                    yield return new PropertyChangedEvent(BuildPath(propertyPath, prop.Name), resourceType.Name, id, userId, newValue);
                 }
             }
         }

--- a/HiP-EventStoreLib/HiP-EventStoreLib.csproj
+++ b/HiP-EventStoreLib/HiP-EventStoreLib.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>PaderbornUniversity.SILab.Hip.EventSourcing</RootNamespace>
     <NoWarn>1701;1702;1705;1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>4.1.1</Version>
+    <Version>4.1.2</Version>
     <Version Condition="'$(VersionSuffix)' != ''">$(Version)-$(VersionSuffix)</Version>
     <Description>Provides core functionality for implementing the event sourcing and CQRS patterns.</Description>
     <PackageLicenseUrl>https://github.com/HiP-App/HiP-EventStoreLib/blob/master/LICENSE</PackageLicenseUrl>
@@ -14,11 +14,11 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="EventStore.ClientAPI.NetCore" Version="4.0.2-rc" />
+    <PackageReference Include="EventStore.ClientAPI.NetCore" Version="4.1.0.23" />
     <PackageReference Include="GitLink" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.0.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.4.4" />
+    <PackageReference Include="MongoDB.Driver" Version="2.5.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0-pre-05" />
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />


### PR DESCRIPTION
This branch deals with the issue that when an entity is created no PropertyChangedEvents are created for value types (int, enum etc.). The CompareEntity method now considers value types for the special case of entity creation